### PR TITLE
API-1581

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenOperation.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenOperation.java
@@ -52,6 +52,24 @@ public class CodegenOperation {
     }
 
     /**
+     * Returns whether or not the operation has any required parameters
+     */
+    public boolean getHasRequiredParams() {
+        List<CodegenParameter> params = getRequiredParams();
+        return (params != null && !params.isEmpty());
+    }
+
+    /**
+     * Returns the title case of the operation ID for generating request objects
+     */
+    public String getRequestClassname() {
+        if (operationId == null || operationId.isEmpty()) {
+            return null;
+        }
+        return DefaultCodegen.camelize(operationId + "Request", false);
+    }
+
+    /**
      * Check if there's at least one parameter
      *
      * @return true if parameter exists, false otherwise

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenParameter.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/CodegenParameter.java
@@ -73,6 +73,13 @@ public class CodegenParameter {
 	 * See http://json-schema.org/latest/json-schema-validation.html#anchor14
 	 */
     public Number multipleOf;
+
+    /**
+     * Returns the title case of the parameter name
+     */
+    public String getParamTitle() {
+        return DefaultCodegen.camelize(paramName, false);
+    }
     
     public CodegenParameter copy() {
         CodegenParameter output = new CodegenParameter();

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultCodegen.java
@@ -2727,7 +2727,7 @@ public class DefaultCodegen {
 
     public String operationFilename(String templateName, String tag) {
         String suffix = operationTemplateFiles().get(templateName);
-        return apiFileFolder() + "/../requestBuilder/" + initialCaps(tag) + suffix;
+        return apiFileFolder() + "/../api/request/" + initialCaps(tag) + suffix;
     }
 
     /**

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/DefaultGenerator.java
@@ -439,7 +439,7 @@ public class DefaultGenerator extends AbstractGenerator implements Generator {
                         for (CodegenOperation apiOperation : (List<CodegenOperation>)api.get("operation")) {
                             // Initialize data object for template
                             Map<String, Object> operationData = new HashMap<>();
-                            operationData.put("package", operation.get("package") + ".requestBuilder");
+                            operationData.put("package", operation.get("package") + ".request");
                             operationData.put("imports", operation.get("imports"));
                             operationData.put("invokerPackage", operation.get("invokerPackage"));
                             operationData.put("modelPackage", operation.get("modelPackage"));

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/JavaClientCodegen.java
@@ -54,6 +54,7 @@ public class JavaClientCodegen extends DefaultCodegen implements CodegenConfig {
         outputFolder = "generated-code" + File.separator + "java";
         modelTemplateFiles.put("model.mustache", ".java");
         apiTemplateFiles.put("api.mustache", ".java");
+        apiTemplateFiles.put("api_async.mustache", "Async.java");
         apiTestTemplateFiles.put("api_test.mustache", ".java");
         embeddedTemplateDir = templateDir = "Java";
         apiPackage = "io.swagger.client.api";

--- a/modules/swagger-codegen/src/main/resources/Java/api_async.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/api_async.mustache
@@ -1,0 +1,101 @@
+package {{package}};
+
+import com.sun.jersey.api.client.GenericType;
+
+import {{invokerPackage}}.ApiException;
+import {{invokerPackage}}.ApiClient;
+import {{invokerPackage}}.Configuration;
+import {{modelPackage}}.*;
+import {{invokerPackage}}.Pair;
+
+{{#imports}}import {{import}};
+{{/imports}}
+
+
+{{^fullJavaUtil}}
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+{{/fullJavaUtil}}
+
+{{>generatedAnnotation}}
+{{#operations}}
+public class {{classname}}Async {
+  private ApiClient {{localVariablePrefix}}apiClient;
+
+  public {{classname}}Async() {
+    this(Configuration.getDefaultApiClient());
+  }
+
+  public {{classname}}Async(ApiClient apiClient) {
+    this.{{localVariablePrefix}}apiClient = apiClient;
+  }
+
+  public ApiClient getApiClient() {
+    return {{localVariablePrefix}}apiClient;
+  }
+
+  public void setApiClient(ApiClient apiClient) {
+    this.{{localVariablePrefix}}apiClient = apiClient;
+  }
+
+  {{#operation}}
+  /**
+   * {{summary}}
+   * {{notes}}{{#allParams}}
+   * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{/allParams}}{{#returnType}}
+   * @return {{{returnType}}}{{/returnType}}
+   * @throws ApiException if fails to make API call
+   */
+  public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) throws ApiException {
+    Object {{localVariablePrefix}}localVarPostBody = {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}};
+    {{#allParams}}{{#required}}
+    // verify the required parameter '{{paramName}}' is set
+    if ({{paramName}} == null) {
+      throw new ApiException(400, "Missing the required parameter '{{paramName}}' when calling {{operationId}}");
+    }
+    {{/required}}{{/allParams}}
+    // create path and map variables
+    String {{localVariablePrefix}}localVarPath = "{{{path}}}".replaceAll("\\{format\\}","json"){{#pathParams}}
+      .replaceAll("\\{" + "{{baseName}}" + "\\}", {{localVariablePrefix}}apiClient.escapeString({{{paramName}}}.toString())){{/pathParams}};
+
+    // query params
+    {{javaUtilPrefix}}List<Pair> {{localVariablePrefix}}localVarQueryParams = new {{javaUtilPrefix}}ArrayList<Pair>();
+    {{javaUtilPrefix}}Map<String, String> {{localVariablePrefix}}localVarHeaderParams = new {{javaUtilPrefix}}HashMap<String, String>();
+    {{javaUtilPrefix}}Map<String, Object> {{localVariablePrefix}}localVarFormParams = new {{javaUtilPrefix}}HashMap<String, Object>();
+
+    {{#queryParams}}
+    {{localVariablePrefix}}localVarQueryParams.addAll({{localVariablePrefix}}apiClient.parameterToPairs("{{#collectionFormat}}{{{collectionFormat}}}{{/collectionFormat}}", "{{baseName}}", {{paramName}}));
+    {{/queryParams}}
+
+    {{#headerParams}}if ({{paramName}} != null)
+      {{localVariablePrefix}}localVarHeaderParams.put("{{baseName}}", {{localVariablePrefix}}apiClient.parameterToString({{paramName}}));
+    {{/headerParams}}
+
+    {{#formParams}}if ({{paramName}} != null)
+      {{localVariablePrefix}}localVarFormParams.put("{{baseName}}", {{paramName}});
+    {{/formParams}}
+
+    final String[] {{localVariablePrefix}}localVarAccepts = {
+      {{#produces}}"{{mediaType}}"{{#hasMore}}, {{/hasMore}}{{/produces}}
+    };
+    final String {{localVariablePrefix}}localVarAccept = {{localVariablePrefix}}apiClient.selectHeaderAccept({{localVariablePrefix}}localVarAccepts);
+
+    final String[] {{localVariablePrefix}}localVarContentTypes = {
+      {{#consumes}}"{{mediaType}}"{{#hasMore}}, {{/hasMore}}{{/consumes}}
+    };
+    final String {{localVariablePrefix}}localVarContentType = {{localVariablePrefix}}apiClient.selectHeaderContentType({{localVariablePrefix}}localVarContentTypes);
+
+    String[] {{localVariablePrefix}}localVarAuthNames = new String[] { {{#authMethods}}"{{name}}"{{#hasMore}}, {{/hasMore}}{{/authMethods}} };
+
+    {{#returnType}}
+    GenericType<{{{returnType}}}> {{localVariablePrefix}}localVarReturnType = new GenericType<{{{returnType}}}>() {};
+    return {{localVariablePrefix}}apiClient.invokeAPI({{localVariablePrefix}}localVarPath, "{{httpMethod}}", {{localVariablePrefix}}localVarQueryParams, {{localVariablePrefix}}localVarPostBody, {{localVariablePrefix}}localVarHeaderParams, {{localVariablePrefix}}localVarFormParams, {{localVariablePrefix}}localVarAccept, {{localVariablePrefix}}localVarContentType, {{localVariablePrefix}}localVarAuthNames, {{localVariablePrefix}}localVarReturnType);
+    {{/returnType}}{{^returnType}}
+    {{localVariablePrefix}}apiClient.invokeAPI({{localVariablePrefix}}localVarPath, "{{httpMethod}}", {{localVariablePrefix}}localVarQueryParams, {{localVariablePrefix}}localVarPostBody, {{localVariablePrefix}}localVarHeaderParams, {{localVariablePrefix}}localVarFormParams, {{localVariablePrefix}}localVarAccept, {{localVariablePrefix}}localVarContentType, {{localVariablePrefix}}localVarAuthNames, null);
+    {{/returnType}}
+  }
+  {{/operation}}
+}
+{{/operations}}


### PR DESCRIPTION
1. Add calculated property for parameters to get the parameter name in title case for class accessor methods, e.g. `foo` -> `getFoo()`
1. Add calculated property for operations to get the request class name in title case with the "Request" suffix.
1. Change package of request POJOs to `~/api/request` instead of `~/api/requestBuilder`
1. Change output directory of request POJOs to match package
1. Add template for asynchronous API class