### PR TITLE
DEVENGAGE-345 add explicit escaping so javadocs don't blow up

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PureCloudJavaClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PureCloudJavaClientCodegen.java
@@ -145,6 +145,16 @@ public class PureCloudJavaClientCodegen extends JavaClientCodegen {
     }
 
     @Override
+    public void postProcessModelProperty(CodegenModel model, CodegenProperty property) {
+        super.postProcessModelProperty(model, property);
+
+        if (property.description != null) {
+            // [DEVENGAGE-345] Escape */* in description - this interferes with javadoc comments and annotations - transforms */* -> *\\/\\*
+            property.description = property.description.replaceAll("\\*/\\*","*\\\\\\\\/\\\\\\\\*");
+        }
+    }
+
+    @Override
     public CodegenModel fromModel(String name, Model model, Map<String, Model> allDefinitions) {
         CodegenModel codegenModel = super.fromModel(name, model, allDefinitions);
 


### PR DESCRIPTION
This is a bit of a hack because it's handing a very specific case, but everything is already escaped "properly" as far as I can tell. The properly escaped value was conflicting with specific javadoc syntax where it thinks that */ is the end of a comment. This was the only thing I could come up with that allowed it to build successfully. 