### PR TITLE
DEVENGAGE-383: Fix the EntityListing object in the Golang SDK

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/GoClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/GoClientCodegen.java
@@ -83,8 +83,8 @@ public class GoClientCodegen extends DefaultCodegen implements CodegenConfig {
         instantiationTypes.clear();
 
         typeMapping.clear();
-        typeMapping.put("integer", "int32");
-        typeMapping.put("long", "int64");
+        typeMapping.put("integer", "int");
+        typeMapping.put("long", "int");
         typeMapping.put("number", "float32");
         typeMapping.put("float", "float32");
         typeMapping.put("double", "float64");

--- a/modules/swagger-codegen/src/test/java/io/swagger/codegen/go/GoModelTest.java
+++ b/modules/swagger-codegen/src/test/java/io/swagger/codegen/go/GoModelTest.java
@@ -42,10 +42,10 @@ public class GoModelTest {
 
         final CodegenProperty property1 = cm.vars.get(0);
         Assert.assertEquals(property1.baseName, "id");
-        Assert.assertEquals(property1.datatype, "int64");
+        Assert.assertEquals(property1.datatype, "int");
         Assert.assertEquals(property1.name, "Id");
         Assert.assertEquals(property1.defaultValue, "null");
-        Assert.assertEquals(property1.baseType, "int64");
+        Assert.assertEquals(property1.baseType, "int");
         Assert.assertTrue(property1.hasMore);
         Assert.assertTrue(property1.required);
         Assert.assertTrue(property1.isPrimitiveType);
@@ -92,10 +92,10 @@ public class GoModelTest {
 
         final CodegenProperty property1 = cm.vars.get(0);
         Assert.assertEquals(property1.baseName, "id");
-        Assert.assertEquals(property1.datatype, "int64");
+        Assert.assertEquals(property1.datatype, "int");
         Assert.assertEquals(property1.name, "Id");
         Assert.assertEquals(property1.defaultValue, "null");
-        Assert.assertEquals(property1.baseType, "int64");
+        Assert.assertEquals(property1.baseType, "int");
         Assert.assertTrue(property1.hasMore);
         Assert.assertTrue(property1.required);
         Assert.assertTrue(property1.isPrimitiveType);


### PR DESCRIPTION
This fix aims at defaulting to int datatype for go lang sdk. Ronan helped to figure it out.
Let me know if there is anything else I have missed.