### PR TITLE
Go SDK: Defining arbitrary objects as interface{}

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PureCloudGoClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PureCloudGoClientCodegen.java
@@ -29,7 +29,7 @@ public class PureCloudGoClientCodegen extends GoClientCodegen {
 
         // Go type for arbitrary objects
         // Mainly used for API types of Map<string, Object>, which are objects with additional properties of type object
-        typeMapping.put("object", "map[string]interface{}");
+        typeMapping.put("object", "interface{}");
 
         typeMapping.put("LocalDateTime", "time.Time");
     }


### PR DESCRIPTION
Fixes https://inindca.atlassian.net/browse/DEVENGAGE-616